### PR TITLE
Remove custom sound option for rest end notification

### DIFF
--- a/src/ProjectEye/Core/Models/Options/GeneralModel.cs
+++ b/src/ProjectEye/Core/Models/Options/GeneralModel.cs
@@ -33,10 +33,6 @@ namespace ProjectEye.Core.Models.Options
         /// </summary>
         public int WarnTime { get; set; } = 20;
         /// <summary>
-        /// 休息结束提示音效文件路径，为空时使用默认
-        /// </summary>
-        public string SoundPath { get; set; } = "";
-        /// <summary>
         /// 休息时间（单位：秒）
         /// </summary>
         public int RestTime { get; set; } = 20;

--- a/src/ProjectEye/Core/Service/SoundService.cs
+++ b/src/ProjectEye/Core/Service/SoundService.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Media;
 using System.Windows;
 using ProjectEye.Core.Enums;
-using ProjectEye.Core.Models.Options;
 
 namespace ProjectEye.Core.Service
 {
@@ -37,17 +36,6 @@ namespace ProjectEye.Core.Service
             players[SoundType.Other].LoadCompleted += Player_LoadCompleted;
 
             LoadConfigSound();
-
-            config.Changed += Config_Changed;
-        }
-
-        private void Config_Changed(object sender, EventArgs e)
-        {
-            var oldOptions = sender as OptionsModel;
-            if (oldOptions.General.SoundPath != config.options.General.SoundPath)
-            {
-                LoadConfigSound();
-            }
         }
 
         /// <summary>
@@ -55,13 +43,8 @@ namespace ProjectEye.Core.Service
         /// </summary>
         private void LoadConfigSound()
         {
-            string restOverPath = null;
-            if (!string.IsNullOrEmpty(config.options.General.SoundPath))
-            {
-                restOverPath = config.options.General.SoundPath;
-            }
             //加载休息结束提示音
-            LoadSound(SoundType.RestOverSound, restOverPath);
+            LoadSound(SoundType.RestOverSound);
         }
         #region 播放音效
         /// <summary>
@@ -127,14 +110,10 @@ namespace ProjectEye.Core.Service
         /// 加载指定音效文件
         /// </summary>
         /// <param name="path">音效文件路径，为空时加载默认音效</param>
-        public void LoadSound(SoundType soundType = SoundType.RestOverSound, string path = null)
+        public void LoadSound(SoundType soundType = SoundType.RestOverSound)
         {
-            var isDefault = false;
-            if (string.IsNullOrEmpty(path))
-            {
-                isDefault = true;
-                path = "/ProjectEye;component/Resources/relentless.wav";
-            }
+            var isDefault = true;
+            var path = "/ProjectEye;component/Resources/relentless.wav";
             var loadResult = Load(soundType, path, isDefault);
             //加载音效失败
             if (!loadResult && !isDefault)

--- a/src/ProjectEye/ViewModels/OptionsViewModel.cs
+++ b/src/ProjectEye/ViewModels/OptionsViewModel.cs
@@ -51,7 +51,6 @@ namespace ProjectEye.ViewModels
             applyCommand = new Command(new Action<object>(applyCommand_action));
             openurlCommand = new Command(new Action<object>(openurlCommand_action));
             inkCommand = new Command(new Action<object>(inkCommand_action));
-            soundTestCommand = new Command(new Action<object>(soundTestCommand_actionAsync));
             updateCommand = new Command(new Action<object>(updateCommand_action));
             showWindowCommand = new Command(new Action<object>(showWindowCommand_action));
             addBreackProcessCommand = new Command(new Action<object>(addBreackProcessCommand_action));
@@ -132,21 +131,6 @@ namespace ProjectEye.ViewModels
 
         }
 
-        private void soundTestCommand_actionAsync(object obj)
-        {
-            var path = "";
-            path = config.options.General.SoundPath;
-            if (!string.IsNullOrEmpty(path))
-            {
-                var resultTest = sound.Test(path);
-                Modal(resultTest ? $"{Application.Current.Resources["Lang_Success"]}" : $"{Application.Current.Resources["Lang_Failed"]}");
-            }
-            else
-            {
-                sound.Play();
-                Modal("Ding!");
-            }
-        }
         private void inkCommand_action(object obj)
         {
 

--- a/src/ProjectEye/Views/OptionsWindow.xaml
+++ b/src/ProjectEye/Views/OptionsWindow.xaml
@@ -135,31 +135,6 @@
                             Cursor="Hand"
                             IsChecked="{Binding Model.Data.General.Sound}"
                             Text="{DynamicResource Lang_Soundforbreakend}" />
-                        <Grid Margin="0 20 0 0">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="auto" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="auto" />
-                            </Grid.ColumnDefinitions>
-                            <!--<TextBlock Grid.Column="0"
-                                   Margin="0,0,10,0" VerticalAlignment="Center">自定义提示音</TextBlock>-->
-
-                            <ui:Project1UIInput
-                                Grid.Column="1"
-                                Width="auto"
-                                ExtNames=".wav|*.wav"
-                                Icon="MusicNote"
-                                Placeholder="{DynamicResource Lang_Leaveblankfordefault}"
-                                Text="{Binding Model.Data.General.SoundPath}"
-                                TextWrapping="NoWrap"
-                                Type="FileSelect" />
-                            <ui:Project1UIButton
-                                Grid.Column="2"
-                                Margin="5 0 0 0"
-                                Command="{Binding soundTestCommand}"
-                                Content="{DynamicResource Lang_Preview}"
-                                Style="{DynamicResource basic}" />
-                        </Grid>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>


### PR DESCRIPTION
Removed SoundPath property and related UI/logic for custom rest end sound. The app now always uses the default sound for rest end notifications, simplifying sound loading and playback code.