### PR TITLE
Update NuGet package versions in EyeProtect.csproj

### DIFF
--- a/src/EyeProtect/EyeProtect.csproj
+++ b/src/EyeProtect/EyeProtect.csproj
@@ -25,8 +25,8 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="iNKORE.UI.WPF.Modern" Version="0.10.2.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.20.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.1" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime.Extensions" Version="0.14.0" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.269">
@@ -35,11 +35,11 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NPSMLib" Version="0.9.14" />
-    <PackageReference Include="Emgu.CV" Version="4.10.0.5671" />
-    <PackageReference Include="Emgu.CV.runtime.windows" Version="4.10.0.5671" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.9" />
-    <PackageReference Include="System.Numerics.Tensors" Version="9.0.9" />
-    <PackageReference Include="System.Runtime.Caching" Version="10.0.2" />
+    <PackageReference Include="Emgu.CV" Version="4.12.0.5764" />
+    <PackageReference Include="Emgu.CV.runtime.windows" Version="4.12.0.5764" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.3" />
+    <PackageReference Include="System.Numerics.Tensors" Version="10.0.3" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded several dependencies to their latest versions, including Microsoft.Extensions.DependencyInjection, Microsoft.ML.OnnxRuntime, Emgu.CV, Emgu.CV.runtime.windows, System.Drawing.Common, System.Numerics.Tensors, and System.Runtime.Caching. No other changes were made.